### PR TITLE
 Return null on unsupported history requests

### DIFF
--- a/QuantConnect.BinanceBrokerage.Tests/BinanceBrokerageDataQueueHandlerTests.cs
+++ b/QuantConnect.BinanceBrokerage.Tests/BinanceBrokerageDataQueueHandlerTests.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@ using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
+using QuantConnect.Tests;
 using System;
 using System.Threading;
 
@@ -30,6 +31,7 @@ namespace QuantConnect.BinanceBrokerage.Tests
         {
             get
             {
+                TestGlobals.Initialize();
                 var FTM_USDT = Symbol.Create("FTMUSDT", SecurityType.Crypto, Market.Binance);
 
                 return new[]

--- a/QuantConnect.BinanceBrokerage.Tests/BinanceBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.BinanceBrokerage.Tests/BinanceBrokerageHistoryProviderTests.cs
@@ -55,37 +55,6 @@ namespace QuantConnect.BinanceBrokerage.Tests
             BaseHistoryTest(symbol, resolution, period, tickType, unsupported, _brokerage);
         }
 
-        [Test]
-        [TestCaseSource(nameof(NoHistory))]
-        public virtual void GetEmptyHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType)
-        {
-            BaseEmptyHistoryTest(symbol, resolution, period, tickType, _brokerage);
-        }
-
-        public static void BaseEmptyHistoryTest(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType, Brokerage brokerage)
-        {
-            var now = DateTime.UtcNow;
-            var request = new HistoryRequest(now.Add(-period),
-                now,
-                typeof(TradeBar),
-                symbol,
-                resolution,
-                SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
-                DateTimeZone.Utc,
-                Resolution.Minute,
-                false,
-                false,
-                DataNormalizationMode.Adjusted,
-                tickType);
-
-            var history = brokerage.GetHistory(request)?.ToList();
-
-            Assert.IsNotNull(history);
-
-            Log.Debug("Data points retrieved: " + history.Count);
-            Assert.AreEqual(0, history.Count);
-        }
-
         public static void BaseHistoryTest(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType, bool unsupported, Brokerage brokerage)
         {
             var now = DateTime.UtcNow;
@@ -135,24 +104,14 @@ namespace QuantConnect.BinanceBrokerage.Tests
             }
         }
 
-        private static TestCaseData[] NoHistory
-        {
-            get
-            {
-                return new[]
-                {
-                    // invalid period
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.Crypto, Market.Binance), Resolution.Daily, TimeSpan.FromDays(-15), TickType.Trade),
-                };
-            }
-        }
-
         private static TestCaseData[] InvalidHistory
         {
             get
             {
                 return new[]
                 {
+                    // invalid period
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.Crypto, Market.Binance), Resolution.Daily, TimeSpan.FromDays(-15), TickType.Trade, true),
                     // invalid symbol
                     new TestCaseData(Symbol.Create("XYZ", SecurityType.Crypto, Market.Binance), Resolution.Daily, TimeSpan.FromDays(15), TickType.Trade, true),
                     // invalid security type

--- a/QuantConnect.BinanceBrokerage.Tests/BinanceCoinFuturesBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.BinanceBrokerage.Tests/BinanceCoinFuturesBrokerageHistoryProviderTests.cs
@@ -43,9 +43,9 @@ namespace QuantConnect.BinanceBrokerage.Tests
         [Test]
         [TestCaseSource(nameof(ValidHistory))]
         [TestCaseSource(nameof(InvalidHistory))]
-        public virtual void GetsHistory(Symbol symbol, Resolution resolution, TimeSpan period, bool throwsException)
+        public virtual void GetsHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType, bool unsupported)
         {
-            BinanceBrokerageHistoryProviderTests.BaseHistoryTest(symbol, resolution, period, throwsException, _brokerage);
+            BinanceBrokerageHistoryProviderTests.BaseHistoryTest(symbol, resolution, period, tickType, unsupported, _brokerage);
         }
 
         [Test]
@@ -62,9 +62,9 @@ namespace QuantConnect.BinanceBrokerage.Tests
                 return new[]
                 {
                     // valid
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, Time.OneHour, false),
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Hour, Time.OneDay, false),
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(15), false),
+                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, Time.OneHour, TickType.Trade, false),
+                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Hour, Time.OneDay, TickType.Trade, false),
+                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(15), TickType.Trade, false),
                 };
             }
         }
@@ -75,9 +75,8 @@ namespace QuantConnect.BinanceBrokerage.Tests
             {
                 return new[]
                 {
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Tick, TimeSpan.FromSeconds(15), TickType.Trade),
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Second, Time.OneMinute, TickType.Trade),
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, Time.OneHour, TickType.Quote),
+                    // invalid period, no error, empty result
+                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, TimeSpan.FromDays(-15), TickType.Trade),
                 };
             }
         }
@@ -88,14 +87,18 @@ namespace QuantConnect.BinanceBrokerage.Tests
             {
                 return new[]
                 {
-                    // invalid period, no error, empty result
-                    new TestCaseData(Symbols.EURUSD, Resolution.Daily, TimeSpan.FromDays(-15), false),
-
-                    // invalid symbol, throws "System.ArgumentException : Unknown symbol: XYZ"
-                    new TestCaseData(Symbol.Create("XYZ", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(15), true),
-
-                    // invalid security type, throws "System.ArgumentException : Invalid security type: Equity"
-                    new TestCaseData(Symbols.AAPL, Resolution.Daily, TimeSpan.FromDays(15), false),
+                    // Invalid type of future
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, TimeSpan.FromSeconds(15), TickType.Trade, true),
+                    // invalid resolution
+                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Tick, TimeSpan.FromSeconds(15), TickType.Trade, true),
+                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Second, Time.OneMinute, TickType.Trade, true),
+                    // invalid tick type
+                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, Time.OneHour, TickType.Quote, true),
+                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, Time.OneHour, TickType.OpenInterest, true),
+                    // invalid symbol
+                    new TestCaseData(Symbol.Create("XYZ", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(15), TickType.Trade, true),
+                    // invalid security type
+                    new TestCaseData(Symbols.AAPL, Resolution.Daily, TimeSpan.FromDays(15), TickType.Trade, true),
                 };
             }
         }

--- a/QuantConnect.BinanceBrokerage.Tests/BinanceCoinFuturesBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.BinanceBrokerage.Tests/BinanceCoinFuturesBrokerageHistoryProviderTests.cs
@@ -48,13 +48,6 @@ namespace QuantConnect.BinanceBrokerage.Tests
             BinanceBrokerageHistoryProviderTests.BaseHistoryTest(symbol, resolution, period, tickType, unsupported, _brokerage);
         }
 
-        [Test]
-        [TestCaseSource(nameof(NoHistory))]
-        public virtual void GetEmptyHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType)
-        {
-            BinanceBrokerageHistoryProviderTests.BaseEmptyHistoryTest(symbol, resolution, period, tickType, _brokerage);
-        }
-
         private static TestCaseData[] ValidHistory
         {
             get
@@ -69,24 +62,14 @@ namespace QuantConnect.BinanceBrokerage.Tests
             }
         }
 
-        private static TestCaseData[] NoHistory
-        {
-            get
-            {
-                return new[]
-                {
-                    // invalid period, no error, empty result
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, TimeSpan.FromDays(-15), TickType.Trade),
-                };
-            }
-        }
-
         private static TestCaseData[] InvalidHistory
         {
             get
             {
                 return new[]
                 {
+                    // invalid period
+                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, TimeSpan.FromDays(-15), TickType.Trade, true),
                     // Invalid type of future
                     new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, TimeSpan.FromSeconds(15), TickType.Trade, true),
                     // invalid resolution

--- a/QuantConnect.BinanceBrokerage.Tests/BinanceFuturesBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.BinanceBrokerage.Tests/BinanceFuturesBrokerageHistoryProviderTests.cs
@@ -48,13 +48,6 @@ namespace QuantConnect.BinanceBrokerage.Tests
             BinanceBrokerageHistoryProviderTests.BaseHistoryTest(symbol, resolution, period, tickType, unsupported, _brokerage);
         }
 
-        [Test]
-        [TestCaseSource(nameof(NoHistory))]
-        public virtual void GetEmptyHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType)
-        {
-            BinanceBrokerageHistoryProviderTests.BaseEmptyHistoryTest(symbol, resolution, period, tickType, _brokerage);
-        }
-
         private static TestCaseData[] ValidHistory
         {
             get
@@ -69,24 +62,14 @@ namespace QuantConnect.BinanceBrokerage.Tests
             }
         }
 
-        private static TestCaseData[] NoHistory
-        {
-            get
-            {
-                return new[]
-                {
-                    // invalid period, no error, empty result
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(-15), TickType.Trade),
-                };
-            }
-        }
-
         private static TestCaseData[] InvalidHistory
         {
             get
             {
                 return new[]
                 {
+                    // invalid period
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(-15), TickType.Trade, true),
                     // invalid resolution
                     new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Tick, TimeSpan.FromSeconds(15), TickType.Trade, true),
                     new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Second, Time.OneMinute, TickType.Trade, true),

--- a/QuantConnect.BinanceBrokerage.Tests/BinanceFuturesBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.BinanceBrokerage.Tests/BinanceFuturesBrokerageHistoryProviderTests.cs
@@ -43,9 +43,9 @@ namespace QuantConnect.BinanceBrokerage.Tests
         [Test]
         [TestCaseSource(nameof(ValidHistory))]
         [TestCaseSource(nameof(InvalidHistory))]
-        public virtual void GetsHistory(Symbol symbol, Resolution resolution, TimeSpan period, bool throwsException)
+        public virtual void GetsHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType, bool unsupported)
         {
-            BinanceBrokerageHistoryProviderTests.BaseHistoryTest(symbol, resolution, period, throwsException, _brokerage);
+            BinanceBrokerageHistoryProviderTests.BaseHistoryTest(symbol, resolution, period, tickType, unsupported, _brokerage);
         }
 
         [Test]
@@ -62,9 +62,9 @@ namespace QuantConnect.BinanceBrokerage.Tests
                 return new[]
                 {
                     // valid
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, Time.OneHour, false),
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Hour, Time.OneDay, false),
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(15), false),
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, Time.OneHour, TickType.Trade, false),
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Hour, Time.OneDay, TickType.Trade, false),
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(15), TickType.Trade, false),
                 };
             }
         }
@@ -75,9 +75,8 @@ namespace QuantConnect.BinanceBrokerage.Tests
             {
                 return new[]
                 {
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Tick, TimeSpan.FromSeconds(15), TickType.Trade),
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Second, Time.OneMinute, TickType.Trade),
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, Time.OneHour, TickType.Quote),
+                    // invalid period, no error, empty result
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(-15), TickType.Trade),
                 };
             }
         }
@@ -88,14 +87,16 @@ namespace QuantConnect.BinanceBrokerage.Tests
             {
                 return new[]
                 {
-                    // invalid period, no error, empty result
-                    new TestCaseData(Symbols.EURUSD, Resolution.Daily, TimeSpan.FromDays(-15), false),
-
-                    // invalid symbol, throws "System.ArgumentException : Unknown symbol: XYZ"
-                    new TestCaseData(Symbol.Create("XYZ", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(15), true),
-
-                    // invalid security type, throws "System.ArgumentException : Invalid security type: Equity"
-                    new TestCaseData(Symbols.AAPL, Resolution.Daily, TimeSpan.FromDays(15), false),
+                    // invalid resolution
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Tick, TimeSpan.FromSeconds(15), TickType.Trade, true),
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Second, Time.OneMinute, TickType.Trade, true),
+                    //invalid tick type
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, Time.OneHour, TickType.Quote, true),
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.CryptoFuture, Market.Binance), Resolution.Minute, Time.OneHour, TickType.OpenInterest, true),
+                    // invalid symbol
+                    new TestCaseData(Symbol.Create("XYZ", SecurityType.CryptoFuture, Market.Binance), Resolution.Daily, TimeSpan.FromDays(15), TickType.Trade, true),
+                    // invalid security type
+                    new TestCaseData(Symbols.AAPL, Resolution.Daily, TimeSpan.FromDays(15), TickType.Trade, true),
                 };
             }
         }

--- a/QuantConnect.BinanceBrokerage.Tests/BinanceUSBrokerageDataQueueHandlerTests.cs
+++ b/QuantConnect.BinanceBrokerage.Tests/BinanceUSBrokerageDataQueueHandlerTests.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,6 +14,7 @@
 */
 
 using NUnit.Framework;
+using QuantConnect.Tests;
 
 namespace QuantConnect.BinanceBrokerage.Tests
 {
@@ -24,6 +25,7 @@ namespace QuantConnect.BinanceBrokerage.Tests
         {
             get
             {
+                TestGlobals.Initialize();
                 var symbol = Symbol.Create("FTMUSDT", SecurityType.Crypto, Market.BinanceUS);
 
                 return new[]

--- a/QuantConnect.BinanceBrokerage.Tests/BinanceUSBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.BinanceBrokerage.Tests/BinanceUSBrokerageHistoryProviderTests.cs
@@ -33,13 +33,6 @@ namespace QuantConnect.BinanceBrokerage.Tests
             base.GetsHistory(symbol, resolution, period, tickType, unsupported);
         }
 
-        [Test]
-        [TestCaseSource(nameof(NoHistory))]
-        public override void GetEmptyHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType)
-        {
-            base.GetEmptyHistory(symbol, resolution, period, tickType);
-        }
-
         private static TestCaseData[] ValidHistory
         {
             get
@@ -54,24 +47,14 @@ namespace QuantConnect.BinanceBrokerage.Tests
             }
         }
 
-        private static TestCaseData[] NoHistory
-        {
-            get
-            {
-                return new[]
-                {
-                    // invalid period, no error, empty result
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.Crypto, Market.BinanceUS), Resolution.Daily, TimeSpan.FromDays(-15), TickType.Trade),
-                };
-            }
-        }
-
         private static TestCaseData[] InvalidHistory
         {
             get
             {
                 return new[]
                 {
+                    // invalid period
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.Crypto, Market.BinanceUS), Resolution.Daily, TimeSpan.FromDays(-15), TickType.Trade, true),
                     // invalid market
                     new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.Crypto, Market.Binance), Resolution.Minute, TimeSpan.FromSeconds(15), TickType.Trade, true),
                     // invalid resolution

--- a/QuantConnect.BinanceBrokerage.ToolBox/BaseDataDownloader.cs
+++ b/QuantConnect.BinanceBrokerage.ToolBox/BaseDataDownloader.cs
@@ -45,27 +45,6 @@ namespace QuantConnect.BinanceBrokerage.ToolBox
             var resolution = dataDownloaderGetParameters.Resolution;
             var startUtc = dataDownloaderGetParameters.StartUtc;
             var endUtc = dataDownloaderGetParameters.EndUtc;
-            var tickType = dataDownloaderGetParameters.TickType;
-
-            if (tickType != TickType.Trade)
-            {
-                return Enumerable.Empty<BaseData>();
-            }
-
-            if (resolution == Resolution.Tick || resolution == Resolution.Second)
-            {
-                throw new ArgumentException($"Resolution not available: {resolution}");
-            }
-
-            if (!SymbolMapper.IsKnownLeanSymbol(symbol))
-            {
-                throw new ArgumentException($"The ticker {symbol.Value} is not available.");
-            }
-
-            if (endUtc < startUtc)
-            {
-                throw new ArgumentException("The end date must be greater or equal than the start date.");
-            }
 
             var historyRequest = new HistoryRequest(
                 startUtc,

--- a/QuantConnect.BinanceBrokerage.ToolBox/BaseDataDownloader.cs
+++ b/QuantConnect.BinanceBrokerage.ToolBox/BaseDataDownloader.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.BinanceBrokerage.ToolBox
                 DataNormalizationMode.Raw,
                 TickType.Trade);
 
-            return Brokerage.GetHistory(historyRequest) ?? Enumerable.Empty<BaseData>();
+            return Brokerage.GetHistory(historyRequest);
         }
 
         /// <summary>

--- a/QuantConnect.BinanceBrokerage.ToolBox/BaseDataDownloader.cs
+++ b/QuantConnect.BinanceBrokerage.ToolBox/BaseDataDownloader.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.BinanceBrokerage.ToolBox
                 DataNormalizationMode.Raw,
                 TickType.Trade);
 
-            return Brokerage.GetHistory(historyRequest);
+            return Brokerage.GetHistory(historyRequest) ?? Enumerable.Empty<BaseData>();
         }
 
         /// <summary>

--- a/QuantConnect.BinanceBrokerage.ToolBox/Program.cs
+++ b/QuantConnect.BinanceBrokerage.ToolBox/Program.cs
@@ -112,6 +112,11 @@ namespace QuantConnect.BinanceBrokerage.ToolBox
                     // Download the data
                     var symbol = downloader.GetSymbol(ticker);
                     var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, fromDate, toDate));
+                    if (data == null)
+                    {
+                        continue;
+                    }
+
                     var bars = data.Cast<TradeBar>().ToList();
 
                     // Save the data (single resolution)

--- a/QuantConnect.BinanceBrokerage/BinanceBrokerage.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceBrokerage.cs
@@ -67,6 +67,7 @@ namespace QuantConnect.BinanceBrokerage
         private bool _unsupportedAssetHistoryLogged;
         private bool _unsupportedResolutionHistoryLogged;
         private bool _unsupportedTickTypeHistoryLogged;
+        private bool _invalidTimeRangeHistoryLogged;
 
         private const int MaximumSymbolsPerConnection = 512;
 
@@ -347,6 +348,17 @@ namespace QuantConnect.BinanceBrokerage
                         $"{request.TickType} tick type not supported, no history returned"));
                 }
 
+                return null;
+            }
+
+            if (request.StartTimeUtc >= request.EndTimeUtc)
+            {
+                if (!_invalidTimeRangeHistoryLogged)
+                {
+                    _invalidTimeRangeHistoryLogged = true;
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidDateRange",
+                        "The history request start date must precede the end date, no history returned"));
+                }
                 return null;
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Returning null on unsupported history requests instead of returning an empty enumerable. This allows to differentiate empty results from unsupported cases.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
