### PR TITLE
Minor fix for CryptoFuture: USDC & BNFCR handling

### DIFF
--- a/QuantConnect.BinanceBrokerage/BinanceFuturesBrokerage.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceFuturesBrokerage.cs
@@ -89,8 +89,9 @@ namespace QuantConnect.Brokerages.Binance
             }
             CurrencyPairUtil.DecomposeCurrencyPair(symbol, out var _, out var quoteCurrency);
 
-            return quoteCurrency.Equals("USDT", System.StringComparison.InvariantCultureIgnoreCase)
-                || quoteCurrency.Equals("BUSD", System.StringComparison.InvariantCultureIgnoreCase);
+            return quoteCurrency.Equals("USDT", StringComparison.InvariantCultureIgnoreCase)
+                || quoteCurrency.Equals("BUSD", StringComparison.InvariantCultureIgnoreCase)
+                || quoteCurrency.Equals("USDC", StringComparison.InvariantCultureIgnoreCase);
         }
 
         /// <summary>

--- a/QuantConnect.BinanceBrokerage/BinanceFuturesRestApiClient.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceFuturesRestApiClient.cs
@@ -100,7 +100,12 @@ namespace QuantConnect.Brokerages.Binance
 
         public override BalanceEntry[] GetCashBalance()
         {
-            return GetCashBalance(_prefixV2);
+            var balances = GetCashBalance(_prefixV2) ?? [];
+            if (!balances.Any(x => x.Asset.Equals("BNFCR", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                balances = balances.Concat([new FutureBalance() { Asset = "BNFCR", WalletBalance = 0 }]).ToArray();
+            }
+            return balances;
         }
 
         /// <summary>


### PR DESCRIPTION
- USDC crypto futures are not coin futures
- Inject BNFCR cash if not present in get cash balance (not used in coin futures or spot)

Closes https://github.com/QuantConnect/Lean/issues/9240