### PR TITLE
fix: `GetOpenOrders` method to `Future Coin`

### DIFF
--- a/QuantConnect.BinanceBrokerage.Tests/BinanceJsonConverterTests.cs
+++ b/QuantConnect.BinanceBrokerage.Tests/BinanceJsonConverterTests.cs
@@ -136,6 +136,60 @@ namespace QuantConnect.Brokerages.Binance.Tests
     ""triggerTime"": 0,
     ""goodTillDate"": 0
 }", "2000000184401794");
+
+                yield return new OrderResponse(OrderType.FutureCoinStopMarket, @"{
+    ""orderId"": 5834920738,
+    ""symbol"": ""SANDUSD_PERP"",
+    ""pair"": ""SANDUSD"",
+    ""status"": ""NEW"",
+    ""clientOrderId"": ""bN3K9RREvxx9drvN1EGth0"",
+    ""price"": ""0"",
+    ""avgPrice"": ""0.00"",
+    ""origQty"": ""1"",
+    ""executedQty"": ""0"",
+    ""cumQty"": ""0"",
+    ""cumBase"": ""0"",
+    ""timeInForce"": ""GTC"",
+    ""type"": ""STOP_MARKET"",
+    ""reduceOnly"": false,
+    ""closePosition"": false,
+    ""side"": ""BUY"",
+    ""positionSide"": ""BOTH"",
+    ""stopPrice"": ""0.0857"",
+    ""workingType"": ""CONTRACT_PRICE"",
+    ""priceProtect"": false,
+    ""origType"": ""STOP_MARKET"",
+    ""selfTradePreventionMode"": ""EXPIRE_MAKER"",
+    ""updateTime"": 1772571245283,
+    ""priceMatch"": ""NONE""
+}", "5834920738");
+
+                yield return new OrderResponse(OrderType.FutureCoinStopLimit, @"{
+    ""orderId"": 5834921880,
+    ""symbol"": ""SANDUSD_PERP"",
+    ""pair"": ""SANDUSD"",
+    ""status"": ""NEW"",
+    ""clientOrderId"": ""pB70Kz7B72u2NfbUtj0lUc"",
+    ""price"": ""0.0825"",
+    ""avgPrice"": ""0.00"",
+    ""origQty"": ""1"",
+    ""executedQty"": ""0"",
+    ""cumQty"": ""0"",
+    ""cumBase"": ""0"",
+    ""timeInForce"": ""GTC"",
+    ""type"": ""STOP"",
+    ""reduceOnly"": false,
+    ""closePosition"": false,
+    ""side"": ""BUY"",
+    ""positionSide"": ""BOTH"",
+    ""stopPrice"": ""0.0859"",
+    ""workingType"": ""CONTRACT_PRICE"",
+    ""priceProtect"": false,
+    ""origType"": ""STOP"",
+    ""selfTradePreventionMode"": ""EXPIRE_MAKER"",
+    ""updateTime"": 1772571305861,
+    ""priceMatch"": ""NONE""
+}", "5834921880");
             }
         }
 
@@ -234,6 +288,60 @@ namespace QuantConnect.Brokerages.Binance.Tests
         ""triggerTime"": 0,
         ""goodTillDate"": 0
     }", "2000000184401794");
+
+                yield return new OrderResponse(OrderType.FutureCoinStopMarket, @"    {
+        ""orderId"": 5834895424,
+        ""symbol"": ""SANDUSD_PERP"",
+        ""pair"": ""SANDUSD"",
+        ""status"": ""NEW"",
+        ""clientOrderId"": ""web_coin_nlle6z9j33xonuhyjxjhz76"",
+        ""price"": ""0"",
+        ""avgPrice"": ""0"",
+        ""origQty"": ""1"",
+        ""executedQty"": ""0"",
+        ""cumBase"": ""0"",
+        ""timeInForce"": ""GTC"",
+        ""type"": ""STOP_MARKET"",
+        ""reduceOnly"": false,
+        ""closePosition"": false,
+        ""side"": ""BUY"",
+        ""positionSide"": ""BOTH"",
+        ""stopPrice"": ""0.0855"",
+        ""workingType"": ""CONTRACT_PRICE"",
+        ""priceProtect"": true,
+        ""origType"": ""STOP_MARKET"",
+        ""selfTradePreventionMode"": ""EXPIRE_MAKER"",
+        ""time"": 1772568178006,
+        ""updateTime"": 1772568178006,
+        ""priceMatch"": ""NONE""
+    }", "5834895424");
+
+                yield return new OrderResponse(OrderType.FutureCoinStopLimit, @"    {
+        ""orderId"": 5834896554,
+        ""symbol"": ""SANDUSD_PERP"",
+        ""pair"": ""SANDUSD"",
+        ""status"": ""NEW"",
+        ""clientOrderId"": ""web_coin_c5vbvaj2gjacm5zzmibjvgf"",
+        ""price"": ""0.0845"",
+        ""avgPrice"": ""0"",
+        ""origQty"": ""1"",
+        ""executedQty"": ""0"",
+        ""cumBase"": ""0"",
+        ""timeInForce"": ""GTC"",
+        ""type"": ""STOP"",
+        ""reduceOnly"": false,
+        ""closePosition"": false,
+        ""side"": ""BUY"",
+        ""positionSide"": ""BOTH"",
+        ""stopPrice"": ""0.0855"",
+        ""workingType"": ""CONTRACT_PRICE"",
+        ""priceProtect"": true,
+        ""origType"": ""STOP"",
+        ""selfTradePreventionMode"": ""EXPIRE_MAKER"",
+        ""time"": 1772568376819,
+        ""updateTime"": 1772568376819,
+        ""priceMatch"": ""NONE""
+    }", "5834896554");
             }
         }
 
@@ -269,8 +377,12 @@ namespace QuantConnect.Brokerages.Binance.Tests
             {
                 case OrderType.FutureAlgoStopLimit:
                 case OrderType.SpotStopLimit:
+                case OrderType.FutureCoinStopLimit:
                     Assert.Greater(raw.StopPrice, 0);
                     Assert.Greater(raw.Price, 0);
+                    break;
+                case OrderType.FutureCoinStopMarket:
+                    Assert.Greater(raw.StopPrice, 0);
                     break;
             }
         }
@@ -529,6 +641,138 @@ namespace QuantConnect.Brokerages.Binance.Tests
         ""V"": ""EXPIRE_MAKER""
     }
 }", "1281704667");
+
+                yield return new OrderResponse(OrderType.FutureCoinMarket, @"{
+    ""e"": ""ORDER_TRADE_UPDATE"",
+    ""T"": 1772573412996,
+    ""E"": 1772573412996,
+    ""i"": ""FzAusRuXAuoCFzSg"",
+    ""o"": {
+        ""s"": ""SANDUSD_PERP"",
+        ""c"": ""web_usdt_vtdcx4sv95iwl5mf9ju6zx7"",
+        ""S"": ""BUY"",
+        ""o"": ""MARKET"",
+        ""f"": ""GTC"",
+        ""q"": ""1"",
+        ""p"": ""0"",
+        ""ap"": ""0.0836"",
+        ""sp"": ""0"",
+        ""x"": ""TRADE"",
+        ""X"": ""FILLED"",
+        ""i"": 5834939854,
+        ""l"": ""1"",
+        ""z"": ""1"",
+        ""L"": ""0.0836"",
+        ""n"": ""0.05980861"",
+        ""N"": ""SAND"",
+        ""T"": 1772573412996,
+        ""t"": 52897735,
+        ""b"": ""0"",
+        ""a"": ""0"",
+        ""m"": false,
+        ""R"": false,
+        ""wt"": ""CONTRACT_PRICE"",
+        ""ot"": ""MARKET"",
+        ""ps"": ""BOTH"",
+        ""cp"": false,
+        ""ma"": ""SAND"",
+        ""rp"": ""0"",
+        ""pP"": false,
+        ""si"": 0,
+        ""ss"": 0,
+        ""V"": ""EXPIRE_MAKER"",
+        ""pm"": ""NONE"",
+        ""er"": ""0""
+    }
+}", "5834939854");
+
+                yield return new OrderResponse(OrderType.FutureCoinStopMarket, @"{
+    ""e"": ""ORDER_TRADE_UPDATE"",
+    ""T"": 1772573616997,
+    ""E"": 1772573616998,
+    ""i"": ""FzAusRuXAuoCFzSg"",
+    ""o"": {
+        ""s"": ""SANDUSD_PERP"",
+        ""c"": ""web_usdt_bbtxn67bpvyjpsqpsnlpdci"",
+        ""S"": ""SELL"",
+        ""o"": ""LIMIT"",
+        ""f"": ""GTC"",
+        ""q"": ""1"",
+        ""p"": ""0.0836"",
+        ""ap"": ""0.0836"",
+        ""sp"": ""0"",
+        ""x"": ""TRADE"",
+        ""X"": ""FILLED"",
+        ""i"": 5834940971,
+        ""l"": ""1"",
+        ""z"": ""1"",
+        ""L"": ""0.0836"",
+        ""n"": ""0.02392344"",
+        ""N"": ""SAND"",
+        ""T"": 1772573616997,
+        ""t"": 52897740,
+        ""b"": ""0"",
+        ""a"": ""0"",
+        ""m"": true,
+        ""R"": false,
+        ""wt"": ""CONTRACT_PRICE"",
+        ""ot"": ""LIMIT"",
+        ""ps"": ""BOTH"",
+        ""cp"": false,
+        ""ma"": ""SAND"",
+        ""rp"": ""0"",
+        ""pP"": false,
+        ""si"": 0,
+        ""ss"": 0,
+        ""V"": ""EXPIRE_MAKER"",
+        ""pm"": ""NONE"",
+        ""er"": ""0""
+    }
+}", "5834940971");
+
+                yield return new OrderResponse(OrderType.FutureCoinStopMarket, @"{
+    ""e"": ""ORDER_TRADE_UPDATE"",
+    ""T"": 1772573992256,
+    ""E"": 1772573992257,
+    ""i"": ""FzAusRuXAuoCFzSg"",
+    ""o"": {
+        ""s"": ""SANDUSD_PERP"",
+        ""c"": ""web_usdt_qvncdefuaj9gkbmejzhik7n"",
+        ""S"": ""BUY"",
+        ""o"": ""MARKET"",
+        ""f"": ""GTC"",
+        ""q"": ""1"",
+        ""p"": ""0"",
+        ""ap"": ""0.0836"",
+        ""sp"": ""0.0836"",
+        ""x"": ""TRADE"",
+        ""X"": ""FILLED"",
+        ""i"": 5834942621,
+        ""l"": ""1"",
+        ""z"": ""1"",
+        ""L"": ""0.0836"",
+        ""n"": ""0.05980861"",
+        ""N"": ""SAND"",
+        ""T"": 1772573992256,
+        ""t"": 52897763,
+        ""b"": ""0"",
+        ""a"": ""0"",
+        ""m"": false,
+        ""R"": false,
+        ""wt"": ""CONTRACT_PRICE"",
+        ""ot"": ""TAKE_PROFIT_MARKET"",
+        ""ps"": ""BOTH"",
+        ""cp"": false,
+        ""ma"": ""SAND"",
+        ""rp"": ""0"",
+        ""pP"": false,
+        ""si"": 0,
+        ""ss"": 0,
+        ""V"": ""EXPIRE_MAKER"",
+        ""pm"": ""NONE"",
+        ""er"": ""0""
+    }
+}", "5834942621");
             }
         }
 
@@ -692,6 +936,10 @@ namespace QuantConnect.Brokerages.Binance.Tests
             FutureAlgoStopLimit,
             FutureAlgoStopMarket,
             NewApiSpotMarket,
+            FutureCoinMarket,
+            FutureCoinLimit,
+            FutureCoinStopMarket,
+            FutureCoinStopLimit
         }
 
         [Test]

--- a/QuantConnect.BinanceBrokerage/BinanceBaseRestApiClient.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceBaseRestApiClient.cs
@@ -270,10 +270,20 @@ namespace QuantConnect.Brokerages.Binance
         }
 
         /// <summary>
+        /// Create new order body payload
+        /// </summary>
+        /// <param name="order">Lean order</param>
+        /// <returns>The payload</returns>
+        protected virtual IDictionary<string, object> CreateOrderBody(Order order)
+        {
+            return CreateOrderBodyCore(order);
+        }
+
+        /// <summary>
         /// Create account new order body payload
         /// </summary>
         /// <param name="order">Lean order</param>
-        protected virtual IDictionary<string, object> CreateOrderBody(Order order)
+        protected IDictionary<string, object> CreateOrderBodyCore(Order order)
         {
             // supported time in force values {GTC, IOC, FOK}
             // use GTC as LEAN doesn't support others yet
@@ -346,6 +356,15 @@ namespace QuantConnect.Brokerages.Binance
         /// </summary>
         /// <param name="order">Lean order</param>
         protected virtual IEnumerable<IDictionary<string, object>> CreateCancelOrderBody(Order order)
+        {
+            return CreateCancelOrderBodyCore(order);
+        }
+
+        /// <summary>
+        /// Create account cancel order body payload
+        /// </summary>
+        /// <param name="order">Lean order</param>
+        protected IEnumerable<IDictionary<string, object>> CreateCancelOrderBodyCore(Order order)
         {
             var symbol = SymbolMapper.GetBrokerageSymbol(order.Symbol);
             foreach (var id in order.BrokerId)

--- a/QuantConnect.BinanceBrokerage/BinanceCoinFuturesRestApiClient.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceCoinFuturesRestApiClient.cs
@@ -17,6 +17,7 @@ using QuantConnect.Securities;
 using System.Collections.Generic;
 using QuantConnect.Brokerages.Binance.Messages;
 using QuantConnect.Util;
+using QuantConnect.Orders;
 
 namespace QuantConnect.Brokerages.Binance
 {
@@ -76,6 +77,37 @@ namespace QuantConnect.Brokerages.Binance
         public override IEnumerable<OpenOrder> GetOpenOrders()
         {
             return GetOpenOrders("openOrders");
+        }
+
+        /// <summary>
+        /// Resolves the REST endpoint used to place an order
+        /// </summary>
+        /// <param name="orderType">The type of order being placed.</param>
+        /// <returns>
+        /// The endpoint path used for placing the order.
+        /// </returns>
+        protected override string ResolveOrderEndpoint(OrderType orderType)
+        {
+            return "order";
+        }
+
+        /// <summary>
+        /// Create new order body payload
+        /// </summary>
+        /// <param name="order">Lean order</param>
+        /// <returns>The payload</returns>
+        protected override IDictionary<string, object> CreateOrderBody(Orders.Order order)
+        {
+            return CreateOrderBodyCore(order);
+        }
+
+        /// <summary>
+        /// Creates cancel request payloads for orders.
+        /// </summary>
+        /// <param name="brokerageIds">The brokerage order identifiers.</param>
+        protected override IEnumerable<IDictionary<string, object>> CreateCancelOrderBody(Orders.Order order)
+        {
+            return CreateCancelOrderBodyCore(order);
         }
     }
 }

--- a/QuantConnect.BinanceBrokerage/Messages/Order.cs
+++ b/QuantConnect.BinanceBrokerage/Messages/Order.cs
@@ -51,6 +51,21 @@ namespace QuantConnect.Brokerages.Binance.Messages
     {
         [JsonProperty("transactTime")]
         public override long Time { get; set; }
+
+        /// <summary>
+        /// The Futures Coin API orders have 'updateTime' instead of 'transactTime'
+        /// </summary>
+        [JsonProperty("updateTime")]
+        protected long UpdateTime
+        {
+            set
+            {
+                if (Time == 0)
+                {
+                    Time = value;
+                }
+            }
+        }
     }
 
     public class AlgoOrder : NewOrder


### PR DESCRIPTION
#### Description
The `BinanceCoinFuturesRestApiClient` inherits `BinanceFuturesRestApiClient` but the FutureCoin doesn't support `openAlgoOrders` endpoint, and we observe an exception below:
<img width="1738" height="359" alt="image" src="https://github.com/user-attachments/assets/5d27792c-a884-4bd8-b633-f90ec1d1ac79" />

#### Related PRs
- https://github.com/QuantConnect/Lean.Brokerages.Binance/pull/62

#### Related Issue
N/a
#### Motivation and Context
Fix all bugs.

#### Requires Documentation Change
N/a

#### How Has This Been Tested?
- Place Limit Order on Binance WebUI and lunch the Lean algortihm:
  <img width="1920" height="411" alt="image" src="https://github.com/user-attachments/assets/1f923497-9670-43c1-81a8-9ae674a0ed8b" />

- `GetOpenOrders()` 3 different order types:
  <img width="1529" height="179" alt="image" src="https://github.com/user-attachments/assets/0ac544ca-dc43-49f6-b814-cc8df95f6753" />



#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
