### PR TITLE
fix: preserve BNFCR in zero-balance filter and emit MiCA warning

### DIFF
--- a/QuantConnect.BinanceBrokerage/BinanceBaseRestApiClient.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceBaseRestApiClient.cs
@@ -190,7 +190,7 @@ namespace QuantConnect.Brokerages.Binance
             return JsonConvert
                 .DeserializeObject<AccountInformation>(response.Content, CreateAccountConverter())
                 .Balances
-                .Where(s => s.Amount != 0)
+                .Where(s => s.Amount != 0 || s.Asset.Equals("BNFCR", StringComparison.InvariantCultureIgnoreCase))
                 .ToArray();
         }
 

--- a/QuantConnect.BinanceBrokerage/BinanceBrokerage.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceBrokerage.cs
@@ -229,8 +229,8 @@ namespace QuantConnect.Brokerages.Binance
             if (balances.Any(b => b.Asset.Equals("BNFCR", StringComparison.InvariantCultureIgnoreCase)))
             {
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "BinanceFuturesCreditsTradingMode",
-                    "Detected BNFCR in account balances — account is operating in MiCA Credits Trading Mode. " +
-                    "Margin handling will include supplementary stablecoin collateral (USDC, BNFCR, FDUSD, etc.)."));
+                    "Binance Futures Credits Trading Mode detected. " +
+                    "Margin will be calculated using all available collateral assets in the account."));
             }
 
             return balances

--- a/QuantConnect.BinanceBrokerage/BinanceBrokerage.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceBrokerage.cs
@@ -226,6 +226,13 @@ namespace QuantConnect.Brokerages.Binance
             if (balances == null || !balances.Any())
                 return new List<CashAmount>();
 
+            if (balances.Any(b => b.Asset.Equals("BNFCR", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "BinanceFuturesCreditsTradingMode",
+                    "Detected BNFCR in account balances — account is operating in MiCA Credits Trading Mode. " +
+                    "Margin handling will include supplementary stablecoin collateral (USDC, BNFCR, FDUSD, etc.)."));
+            }
+
             return balances
                 .Select(b => new CashAmount(b.Amount, b.Asset.LazyToUpper()))
                 .ToList();

--- a/QuantConnect.BinanceBrokerage/BinanceFuturesRestApiClient.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceFuturesRestApiClient.cs
@@ -100,12 +100,7 @@ namespace QuantConnect.Brokerages.Binance
 
         public override BalanceEntry[] GetCashBalance()
         {
-            var balances = GetCashBalance(_prefixV2) ?? [];
-            if (!balances.Any(x => x.Asset.Equals("BNFCR", StringComparison.InvariantCultureIgnoreCase)))
-            {
-                balances = balances.Concat([new FutureBalance() { Asset = "BNFCR", WalletBalance = 0 }]).ToArray();
-            }
-            return balances;
+            return GetCashBalance(_prefixV2) ?? [];
         }
 
         /// <summary>

--- a/QuantConnect.BinanceBrokerage/Messages/Balance.cs
+++ b/QuantConnect.BinanceBrokerage/Messages/Balance.cs
@@ -39,7 +39,13 @@ namespace QuantConnect.Brokerages.Binance.Messages
     public class FutureBalance : BalanceEntry
     {
         public decimal WalletBalance { get; set; }
-        public override decimal Amount => WalletBalance;
+        public decimal AvailableBalance { get; set; }
+
+        // For BNFCR: Binance stores the total cross-margin available balance (all stablecoins
+        // aggregated, minus used margin) in availableBalance. walletBalance is the raw BNFCR
+        // token amount which can be negative for EU users (fees charged in BNFCR).
+        // For all other assets: walletBalance is correct.
+        public override decimal Amount => Asset == "BNFCR" ? AvailableBalance : WalletBalance;
     }
 #pragma warning restore 1591
 }

--- a/QuantConnect.BinanceBrokerage/Messages/Balance.cs
+++ b/QuantConnect.BinanceBrokerage/Messages/Balance.cs
@@ -39,13 +39,7 @@ namespace QuantConnect.Brokerages.Binance.Messages
     public class FutureBalance : BalanceEntry
     {
         public decimal WalletBalance { get; set; }
-        public decimal AvailableBalance { get; set; }
-
-        // For BNFCR: Binance stores the total cross-margin available balance (all stablecoins
-        // aggregated, minus used margin) in availableBalance. walletBalance is the raw BNFCR
-        // token amount which can be negative for EU users (fees charged in BNFCR).
-        // For all other assets: walletBalance is correct.
-        public override decimal Amount => Asset == "BNFCR" ? AvailableBalance : WalletBalance;
+        public override decimal Amount => WalletBalance;
     }
 #pragma warning restore 1591
 }


### PR DESCRIPTION
#### Description
For EU/EEA Binance accounts under MiCA Credits Trading Mode, BNFCR is always present in the futures account balance response. Previously, the zero-balance filter in `GetCashBalance` removed BNFCR when `walletBalance=0`, preventing `BinanceCryptoFutureMarginModel` in Lean from detecting EU accounts and aggregating supplementary collateral.

This PR:
1. Adds a BNFCR exception to the zero-balance filter in `BinanceBaseRestApiClient` so BNFCR always passes through to CashBook
2. Removes the manual BNFCR injection in `BinanceFuturesRestApiClient` (no longer needed)
3. Reverts `FutureBalance.Amount` to use `walletBalance` only (`availableBalance` includes unrealized PnL and deducts initial margin, causing double-counting with Lean's TPV tracking)
4. Emits a `BrokerageMessageEvent` warning when BNFCR is detected, so users and logs clearly indicate the account is in MiCA Credits Trading Mode

#### Related PR(s)
QuantConnect/Lean#9373

#### Related Issue
QuantConnect/Lean#9339

#### Motivation and Context
EU users with BNFCR need supplementary collateral (USDC, BTC, ETH, BNB, etc.) aggregated for USDⓈ-M futures margin. The brokerage must preserve BNFCR in the balance response so the margin model in Lean can detect MiCA mode and iterate all collateral assets.

#### Requires Documentation Change
No

#### How Has This Been Tested?
- Verified against real Binance EU account API response
- `BinanceCryptoFutureMarginModel` unit tests in Lean (all passing)
- Regression algorithm `BinanceCryptoFutureBnfcrCollateralRegressionAlgorithm` in Lean
- Warning message:
  <img width="1875" height="43" alt="image" src="https://github.com/user-attachments/assets/b3ace39f-903c-48a1-ba8e-cd2517841daf" />


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`