### PR TITLE
fix: use fstream.binancefuture.com host for paper trading

### DIFF
--- a/QuantConnect.BinanceBrokerage.Tests/BinanceBrokerageAdditionalTests.cs
+++ b/QuantConnect.BinanceBrokerage.Tests/BinanceBrokerageAdditionalTests.cs
@@ -161,7 +161,7 @@ namespace QuantConnect.Brokerages.Binance.Tests
         [TestCase("wss://fstream.binance.com/private/ws/", ExpectedResult = "wss://fstream.binance.com/private/ws")]
         [TestCase("wss://fstream.binance.com/market/ws", ExpectedResult = "wss://fstream.binance.com/private/ws")]
         [TestCase("wss://fstream.binance.com/public/ws", ExpectedResult = "wss://fstream.binance.com/private/ws")]
-        [TestCase("wss://stream.binancefuture.com/ws", ExpectedResult = "wss://stream.binancefuture.com/private/ws")]
+        [TestCase("wss://fstream.binancefuture.com/ws", ExpectedResult = "wss://fstream.binancefuture.com/private/ws")]
         public string GetPrivateWsUrlTests(string inputUrl)
         {
             return BinanceFuturesBrokerageFactory.GetPrivateWsUrl(inputUrl);

--- a/QuantConnect.BinanceBrokerage/BinanceFuturesBrokerageFactory.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceFuturesBrokerageFactory.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Brokerages.Binance
             { "binance-api-key", Config.Get("binance-api-key")},
             { "binance-api-secret", Config.Get("binance-api-secret")},
 
-            // paper trading available using https://testnet.binancefuture.com
+            // paper trading available using https://demo-fapi.binance.com
             { ApiUrlKeyName, Config.Get(ApiUrlKeyName, "https://fapi.binance.com")},
             // paper trading available using wss://fstream.binancefuture.com/private/ws
             { WebSocketUrlKeyName, Config.Get(WebSocketUrlKeyName, $"wss://{LiveHost}/ws")},

--- a/QuantConnect.BinanceBrokerage/BinanceFuturesBrokerageFactory.cs
+++ b/QuantConnect.BinanceBrokerage/BinanceFuturesBrokerageFactory.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Brokerages.Binance
         public static readonly string ApiUrlKeyName = "binance-fapi-url";
         public static readonly string WebSocketUrlKeyName = "binance-fwebsocket-url";
         private const string LiveHost = "fstream.binance.com";
-        private const string PaperHost = "stream.binancefuture.com";
+        private const string PaperHost = "fstream.binancefuture.com";
 
         /// <summary>
         /// Factory constructor
@@ -57,7 +57,7 @@ namespace QuantConnect.Brokerages.Binance
 
             // paper trading available using https://testnet.binancefuture.com
             { ApiUrlKeyName, Config.Get(ApiUrlKeyName, "https://fapi.binance.com")},
-            // paper trading available using wss://stream.binancefuture.com/private/ws
+            // paper trading available using wss://fstream.binancefuture.com/private/ws
             { WebSocketUrlKeyName, Config.Get(WebSocketUrlKeyName, $"wss://{LiveHost}/ws")},
         };
 
@@ -105,7 +105,7 @@ namespace QuantConnect.Brokerages.Binance
         /// <summary>
         /// Builds the user-data WebSocket endpoint for the configured Binance Futures host.
         /// Recognizes the live host <c>fstream.binance.com</c> and the paper/testnet host
-        /// <c>stream.binancefuture.com</c>; any path on the input is ignored and the result
+        /// <c>fstream.binancefuture.com</c>; any path on the input is ignored and the result
         /// is always <c>wss://{host}/private/ws</c>.
         /// </summary>
         public static string GetPrivateWsUrl(string configuredUrl)


### PR DESCRIPTION
#### Description

Two fixes for USDS-M Futures paper-trading endpoints documented in [Binance General Info](https://developers.binance.com/docs/derivatives/usds-margined-futures/general-info):

- **WS host**: `PaperHost` was set to `stream.binancefuture.com`, missing the leading `f`. The correct testnet WS base is `wss://fstream.binancefuture.com`. Fixes the constant, the inline comment, the XML doc on `GetPrivateWsUrl`, and the matching test case.
- **REST host comment**: the paper-trading comment pointed at `https://testnet.binancefuture.com` (legacy UI host, now redirects to `demo.binance.com`). Updated to the documented testnet REST base `https://demo-fapi.binance.com`.

#### Related PR(s)

#76 (introduced the WS typo when migrating to the `/public`, `/market`, `/private/ws` split)

#### Related Issue

closes #75

#### Motivation and Context

`GetPrivateWsUrl` validates the configured host against `LiveHost` and `PaperHost`. With the wrong testnet name, anyone pointing `binance-fwebsocket-url` at the real testnet (`wss://fstream.binancefuture.com/...`) hits:

```
ArgumentException: Unsupported Binance Futures WebSocket host fstream.binancefuture.com. Expected fstream.binance.com (live) or stream.binancefuture.com (paper).
```

so paper-trading on USDS-Futures could not connect.

The REST comment update is non-functional but keeps the paper-trading guidance in sync with the current Binance docs.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

- Updated `BinanceBrokerageAdditionalTests.GetPrivateWsUrlTests` test case for the testnet host (`wss://fstream.binancefuture.com/ws` → `wss://fstream.binancefuture.com/private/ws`).
- All existing `GetPrivateWsUrlTests` cases for the live host still pass unchanged.
- Verified `https://demo-fapi.binance.com/fapi/v1/ping` returns 200.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`